### PR TITLE
docs(google): narrow calendar scope to calendar.acls

### DIFF
--- a/integrations/google-workspace.mdx
+++ b/integrations/google-workspace.mdx
@@ -74,7 +74,7 @@ June requests the following permissions to provide comprehensive asset managemen
 | `admin.directory.group` | Managing Google Groups: create, update, and delete groups for automated team management |
 | `admin.directory.group.member` | Managing group memberships: add or remove users from groups for access control automation |
 | `admin.directory.user` | User lifecycle management: create, suspend, restore, and update user accounts for automated provisioning |
-| `calendar` | Calendar access management: add or remove user access to shared calendars during onboarding/offboarding |
+| `calendar.acls` | Calendar sharing management: add or remove a user's access to shared calendars during onboarding/offboarding. Scoped to access-control (ACL) changes only — June does not read, create, or modify calendar events. |
 | `gmail.settings.sharing` | Email forwarding configuration: set up email forwarding for departing employees |
 | `gmail.settings.basic` | Gmail settings management: configure basic Gmail settings for user accounts |
 


### PR DESCRIPTION
## What

Updates the Google Workspace integration docs to document the narrower `calendar.acls` OAuth scope in place of the broad `calendar` scope.

## Why

The integration only calls the Google Calendar **ACL endpoints** — `insert_acl` / `list_acls` / `delete_acl` (`june-api`, `app/services/integrations/idp/google_service.rb:129-194`) — to add and remove a user's access to shared calendars during onboarding/offboarding. It never reads, creates, or modifies calendar events (verified: zero Events-resource usage across the repo).

The bare `calendar` scope additionally grants full read/write on every event on every calendar, which June uses none of. Google's dedicated `calendar.acls` scope ("See and change the sharing permissions of Google calendars you own") covers all three ACL methods and exactly matches the function.

## Changes

- `integrations/google-workspace.mdx` — Write Permissions table: `calendar` → `calendar.acls`, with explicit "ACL changes only — June does not read, create, or modify calendar events" disclosure language.

## Follow-up (code, separate change)

This doc lands ahead of the code change. To complete least-privilege, swap the requested scope in `june-client` (`src/utils/oauth/google.ts`): `auth/calendar` → `auth/calendar.acls`, and update the Google Cloud Console OAuth consent screen scope list to match. Connected orgs re-consent on next connect (`prompt: consent` already set). No `june-api` changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)