### PR TITLE
docs(ai-spend): add Cursor + require the Claude Enterprise compliance key [JUN-865]

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,7 +96,8 @@
             "group": "AI Tools",
             "pages": [
               "integrations/claude-enterprise",
-              "integrations/claude-platform"
+              "integrations/claude-platform",
+              "integrations/cursor"
             ]
           }
         ]

--- a/integrations/ai-tools.mdx
+++ b/integrations/ai-tools.mdx
@@ -21,6 +21,14 @@ description: 'Connect your AI tools with June to track spend over time, by model
     <div className="text-base font-bold text-white my-2">Claude Platform</div>
     <div className="text-sm text-gray-400">Billed Claude bill at the organization level, plus estimated per-person Claude Code usage</div>
   </Card>
+
+  <Card href="/integrations/cursor">
+    <div className="w-30 h-30">
+      <img src="/images/cursor-dark-mode.svg" alt="Cursor" width={40} height={40} className="my-5" />
+    </div>
+    <div className="text-base font-bold text-white my-2">Cursor</div>
+    <div className="text-sm text-gray-400">Billed, per-person Cursor spend, with no estimates</div>
+  </Card>
 </CardGroup>
 
 ## What Gets Synced
@@ -33,5 +41,5 @@ description: 'Connect your AI tools with June to track spend over time, by model
 | **Per person** | Spend and token usage attributed to each employee |
 
 <Note>
-What June can attribute per person depends on the connection. **Claude Enterprise** gives billed, per-person spend across all products. **Claude Platform** gives your billed organization total plus an estimated per-person figure for Claude Code. See each page for details.
+What June can attribute per person depends on the connection. **Claude Enterprise** gives billed, per-person spend across all products. **Claude Platform** gives your billed organization total plus an estimated per-person figure for Claude Code. **Cursor** gives billed, per-person spend with no estimates. See each page for details.
 </Note>

--- a/integrations/claude-enterprise.mdx
+++ b/integrations/claude-enterprise.mdx
@@ -7,8 +7,9 @@ icon: '/images/claude.svg'
 This is the recommended way to connect Claude. If you're on the Anthropic Console / API instead, see [Claude Platform](/integrations/claude-platform).
 
 ## What you'll accomplish
-- Connect with your claude.ai **Analytics API key**
+- Connect with your claude.ai **Analytics API key** and **Compliance API key**
 - Track **billed** Claude spend over time, by model, by department, and per person
+- See every Claude seat, including people who have access but no usage (the seats you may be paying for and not using)
 - Identify top users and the teams driving usage
 - Get per-person totals that reconcile to your Anthropic bill
 
@@ -18,8 +19,13 @@ From your Claude Enterprise account, June syncs:
 
 - **Billed spend per person**, across **all** Claude products (chat, Code, and more)
 - **Token usage per person**
+- **Your member roster**, so June can show every seat, including people with no usage
 
 Because every figure is billed and attributed to a person, your per-person and per-department totals reconcile to your Anthropic invoice. Usage history is available from January 2026 onward and refreshes daily.
+
+<Note>
+Claude Enterprise uses **two keys**: the **Analytics** key reads your spend and usage, and the **Compliance** key reads your member roster so June can show every seat (including unused ones). Both are required.
+</Note>
 
 ## Capabilities
 
@@ -30,14 +36,15 @@ This is a read-only spend integration. June ingests usage and billing data, and 
 | **Billed spend** | Your authoritative Anthropic invoice total over the selected period, net of account credits. |
 | **Spend over time** | Cumulative spend/tokens by model or department across the period. |
 | **Per-person spend (billed)** | Billed spend and tokens attributed to each employee, across all Claude products. Searchable, sortable, and groupable by department. |
+| **Seat coverage** | Every Claude seat in one view, including unused (idle) seats. Surfaces who has access but no usage, and people who left but still hold a seat. |
 | **Per-department & per-model breakdowns** | Where spend concentrates, plus top users. |
 | **Credits reconciliation** | Used spend minus account credits equals your billed total, surfaced explicitly. |
 
 ## Prerequisites
 
 Before starting, ensure you have:
-- A Claude **Enterprise** (claude.ai) plan
-- **Primary Owner** access to generate an Analytics API key
+- A Claude **Enterprise** (claude.ai) plan, with the **Compliance API** enabled for your organization
+- **Primary Owner** access to generate API keys
 
 ## Connect Claude Enterprise
 
@@ -45,14 +52,20 @@ Before starting, ensure you have:
   <Step title="Generate an Analytics API key">
     1. Sign in to [claude.ai](https://claude.ai) as a **Primary Owner**.
     2. Go to **Analytics → API keys**.
-    3. Create a new key and copy it.
+    3. Create a new key and copy it. This is your **Analytics API key** (it carries the `read:analytics` scope by default).
+  </Step>
+  <Step title="Generate a Compliance API key">
+    This key lets June read your member roster, so it can show every seat (including unused ones).
+    1. Go to **Organization settings → API** and create a key.
+    2. Select the **`read:compliance_user_data`** and **`read:compliance_org_data`** scopes, and copy it. This is your **Compliance API key**.
+    3. If those scopes aren't available, your organization needs the **Compliance API** enabled first. Request it from Anthropic, then create the key.
   </Step>
   <Step title="Add the integration in June">
     1. In June, open the **Integrations** page.
     2. Choose **Claude Enterprise**.
-    3. Paste your **Analytics API key** and save.
+    3. Paste your **Analytics API key** and your **Compliance API key**, then save.
   </Step>
   <Step title="Wait for the first sync">
-    June backfills your historical usage and refreshes daily. Spend and per-person data appear under **AI usage → Claude** once the first sync completes.
+    June backfills your historical usage and refreshes daily. Spend, per-person data, and seats appear under **AI usage → Claude** once the first sync completes.
   </Step>
 </Steps>

--- a/integrations/cursor.mdx
+++ b/integrations/cursor.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Cursor Integration'
+description: 'Connect Cursor with June to track billed, per-person Cursor spend over time, by model, by department, and per person'
+icon: '/images/cursor-dark-mode.svg'
+---
+
+Connect your Cursor team to track billed Cursor spend, attributed to each person, with no estimates.
+
+## What you'll accomplish
+- Connect with your Cursor **Team Admin API key**
+- Track **billed** Cursor spend over time, by model, by department, and per person
+- See every Cursor seat, including people who have access but no usage (the seats you may be paying for and not using)
+- Identify top users and the teams driving usage
+
+## What June syncs
+
+From your Cursor team, June syncs:
+
+- **Billed spend per person** (the amount Cursor actually charges, in cents)
+- **Token usage per person**
+- **Your team roster**, so June can show every seat, including people with no usage
+
+Every figure is billed and attributed to a person, so your per-person and per-department totals are exact, not estimated. Usage history is available from January 2026 onward and refreshes daily.
+
+## Capabilities
+
+This is a read-only spend integration. June ingests usage and billing data, and does not take actions in Cursor.
+
+| Capability | Description |
+|------------|-------------|
+| **Billed spend** | The amount Cursor charges over the selected period. Seat-covered (included) usage shows at $0 but still counts as activity. |
+| **Spend over time** | Cumulative spend/tokens by model or department across the period. |
+| **Per-person spend (billed)** | Billed spend and tokens attributed to each employee. Searchable, sortable, and groupable by department. |
+| **Seat coverage** | Every Cursor seat in one view, including unused (idle) seats. Surfaces who has access but no usage, and people who left but still hold a seat. |
+| **Per-department & per-model breakdowns** | Where spend concentrates, plus top users. |
+
+## Prerequisites
+
+Before starting, ensure you have:
+- A Cursor team on a plan with **Admin API** access (Business or Enterprise)
+- **Admin** access to create a Team Admin API key
+
+## Connect Cursor
+
+<Steps>
+  <Step title="Generate a Team Admin API key">
+    1. Sign in to your Cursor team's dashboard as an **admin**.
+    2. Go to **Settings** and create a **Team Admin API key**.
+    3. Copy the key.
+  </Step>
+  <Step title="Add the integration in June">
+    1. In June, open the **Integrations** page.
+    2. Choose **Cursor**.
+    3. Paste your **Team Admin API key** and save.
+  </Step>
+  <Step title="Wait for the first sync">
+    June backfills your historical usage and refreshes daily. Spend, per-person data, and seats appear under **AI usage → Cursor** once the first sync completes.
+  </Step>
+</Steps>


### PR DESCRIPTION
## Summary

Docs for the AI-spend work on jun-865: the new **Cursor** integration and the updated **Claude Enterprise** setup (now needs a second key).

## Changes

- **Claude Enterprise (`integrations/claude-enterprise.mdx`)** — Enterprise now requires **two keys**: the Analytics key (spend) and a **Compliance API key** (the member roster / idle seats). Documents how to create the compliance key (scopes `read:compliance_user_data` + `read:compliance_org_data`, with the "enable Compliance API first" fallback) so a connection no longer silently fails at "add the compliance key." Analytics key step left as a plain key (it carries `read:analytics` by default). Added the **Seat coverage** capability and a two-key note.
- **Cursor (`integrations/cursor.mdx`, new)** — Team Admin API key, billed per-person spend (no estimates), seat coverage.
- **AI tools overview (`integrations/ai-tools.mdx`) + nav (`docs.json`)** — Cursor card (dark-mode logo) + nav entry, and the per-person note updated.

Customer-facing only (no endpoints/sync internals), voice-checked, no em-dashes.

## Note on base

Based on `integration-docs-comms-procurement` (not `main`) because that branch introduces the AI-tools pages this builds on. Once it lands on `main`, this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)