### PR TITLE
docs(ai-spend): add OpenAI integration page [JUN-864]

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -97,7 +97,8 @@
             "pages": [
               "integrations/claude-enterprise",
               "integrations/claude-platform",
-              "integrations/cursor"
+              "integrations/cursor",
+              "integrations/openai"
             ]
           }
         ]

--- a/integrations/ai-tools.mdx
+++ b/integrations/ai-tools.mdx
@@ -29,6 +29,14 @@ description: 'Connect your AI tools with June to track spend over time, by model
     <div className="text-base font-bold text-white my-2">Cursor</div>
     <div className="text-sm text-gray-400">Billed, per-person Cursor spend, with no estimates</div>
   </Card>
+
+  <Card href="/integrations/openai">
+    <div className="w-30 h-30">
+      <img src="/images/openai-dark-mode.svg" alt="OpenAI" width={40} height={40} className="my-5" />
+    </div>
+    <div className="text-base font-bold text-white my-2">OpenAI</div>
+    <div className="text-sm text-gray-400">Billed, per-person OpenAI spend, with no estimates</div>
+  </Card>
 </CardGroup>
 
 ## What Gets Synced
@@ -41,5 +49,5 @@ description: 'Connect your AI tools with June to track spend over time, by model
 | **Per person** | Spend and token usage attributed to each employee |
 
 <Note>
-What June can attribute per person depends on the connection. **Claude Enterprise** gives billed, per-person spend across all products. **Claude Platform** gives your billed organization total plus an estimated per-person figure for Claude Code. **Cursor** gives billed, per-person spend with no estimates. See each page for details.
+What June can attribute per person depends on the connection. **Claude Enterprise** gives billed, per-person spend across all products. **Claude Platform** gives your billed organization total plus an estimated per-person figure for Claude Code. **Cursor** gives billed, per-person spend with no estimates. **OpenAI** gives billed, per-person spend for your OpenAI organization, with shared or automated usage surfaced at the organization level. See each page for details.
 </Note>

--- a/integrations/ai-tools.mdx
+++ b/integrations/ai-tools.mdx
@@ -34,8 +34,8 @@ description: 'Connect your AI tools with June to track spend over time, by model
     <div className="w-30 h-30">
       <img src="/images/openai-dark-mode.svg" alt="OpenAI" width={40} height={40} className="my-5" />
     </div>
-    <div className="text-base font-bold text-white my-2">OpenAI</div>
-    <div className="text-sm text-gray-400">Billed, per-person OpenAI spend, with no estimates</div>
+    <div className="text-base font-bold text-white my-2">OpenAI Platform</div>
+    <div className="text-sm text-gray-400">Billed, per-person OpenAI API spend, with no estimates</div>
   </Card>
 </CardGroup>
 
@@ -49,5 +49,5 @@ description: 'Connect your AI tools with June to track spend over time, by model
 | **Per person** | Spend and token usage attributed to each employee |
 
 <Note>
-What June can attribute per person depends on the connection. **Claude Enterprise** gives billed, per-person spend across all products. **Claude Platform** gives your billed organization total plus an estimated per-person figure for Claude Code. **Cursor** gives billed, per-person spend with no estimates. **OpenAI** gives billed, per-person spend for your OpenAI organization, with shared or automated usage surfaced at the organization level. See each page for details.
+What June can attribute per person depends on the connection. **Claude Enterprise** gives billed, per-person spend across all products. **Claude Platform** gives your billed organization total plus an estimated per-person figure for Claude Code. **Cursor** gives billed, per-person spend with no estimates. **OpenAI Platform** gives billed, per-person spend for your OpenAI API usage, with shared or automated usage surfaced at the organization level. See each page for details.
 </Note>

--- a/integrations/openai.mdx
+++ b/integrations/openai.mdx
@@ -1,0 +1,62 @@
+---
+title: 'OpenAI Integration'
+description: 'Connect OpenAI with June to track billed, per-person OpenAI spend over time, by model, by department, and per person'
+icon: '/images/openai-dark-mode.svg'
+---
+
+Connect your OpenAI organization to track billed OpenAI spend, attributed to each person, with no estimates.
+
+This connects your **OpenAI organization** (the API and platform bill). It does not cover ChatGPT Business or Enterprise seats, which are billed separately.
+
+## What you'll accomplish
+- Connect with your OpenAI **Admin API key**
+- Track **billed** OpenAI spend over time, by model, by department, and per person
+- See everyone in your OpenAI organization, including people with no usage
+- Identify top users and the teams driving spend
+
+## What June syncs
+
+From your OpenAI organization, June syncs:
+
+- **Billed spend per person** (the amount OpenAI actually charges, attributed to each person who uses it)
+- **Token usage per person**
+- **Your member roster**, so June can show everyone, including people with no usage
+
+Every figure is billed and attributed to a person, so your per-person and per-department totals are exact, not estimated. Usage that isn't tied to an individual (shared or automated activity) rolls up at the organization level. Usage history is available from January 2026 onward and refreshes daily.
+
+## Capabilities
+
+This is a read-only spend integration. June ingests usage and billing data, and does not take actions in OpenAI.
+
+| Capability | Description |
+|------------|-------------|
+| **Billed spend** | The amount OpenAI charges over the selected period, by model. |
+| **Spend over time** | Cumulative spend/tokens by model or department across the period. |
+| **Per-person spend (billed)** | Billed spend and tokens attributed to each person. Searchable, sortable, and groupable by department. |
+| **Organization-level spend** | Shared or automated usage that isn't tied to a person, surfaced separately so totals always reconcile to your OpenAI bill. |
+| **Member visibility** | Everyone in your OpenAI organization in one view, including people with no usage and people who left. |
+| **Per-department & per-model breakdowns** | Where spend concentrates, plus top users. |
+
+## Prerequisites
+
+Before starting, ensure you have:
+- An OpenAI organization with **Admin API key** access
+- **Owner** access to create an Admin API key
+
+## Connect OpenAI
+
+<Steps>
+  <Step title="Generate an Admin API key">
+    1. Sign in to your OpenAI organization as an **Owner**.
+    2. Go to your **Organization settings** and create an **Admin API key**.
+    3. Copy the key.
+  </Step>
+  <Step title="Add the integration in June">
+    1. In June, open the **Integrations** page.
+    2. Choose **OpenAI**.
+    3. Paste your **Admin API key** and save.
+  </Step>
+  <Step title="Wait for the first sync">
+    June backfills your historical usage and refreshes daily. Spend, per-person data, and members appear under **AI usage → OpenAI** once the first sync completes.
+  </Step>
+</Steps>

--- a/integrations/openai.mdx
+++ b/integrations/openai.mdx
@@ -43,13 +43,20 @@ Before starting, ensure you have:
 - An OpenAI organization with **Admin API key** access
 - **Owner** access to create an Admin API key
 
+June only ever reads from OpenAI, so a **read-only** key is all it needs.
+
 ## Connect OpenAI
 
 <Steps>
-  <Step title="Generate an Admin API key">
+  <Step title="Generate a read-only Admin API key">
     1. Sign in to your OpenAI organization as an **Owner**.
-    2. Go to your **Organization settings** and create an **Admin API key**.
-    3. Copy the key.
+    2. Go to **Organization settings → Admin keys** and choose **Create new admin key**.
+    3. Give it a name (for example, "June") and, under **Permissions**, select **Read only**. June never writes to your OpenAI account, so read-only access is all it needs.
+    4. Create the key and copy it.
+
+    <Note>
+    Prefer least privilege? Choose **Restricted** instead and set **Usage API Scope** and **Organization Administration** to **Read** (leave the others **None**). June reads your spend and usage through the Usage API, and your member roster through Organization Administration, so both are required. A key missing Organization Administration will fail to connect.
+    </Note>
   </Step>
   <Step title="Add the integration in June">
     1. In June, open the **Integrations** page.

--- a/integrations/openai.mdx
+++ b/integrations/openai.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'OpenAI Integration'
-description: 'Connect OpenAI with June to track billed, per-person OpenAI spend over time, by model, by department, and per person'
+title: 'OpenAI Platform Integration'
+description: 'Connect the OpenAI Platform with June to track billed, per-person OpenAI API spend over time, by model, by department, and per person'
 icon: '/images/openai-dark-mode.svg'
 ---
 
-Connect your OpenAI organization to track billed OpenAI spend, attributed to each person, with no estimates.
+Connect your OpenAI Platform account (API access) to track billed OpenAI spend, attributed to each person, with no estimates.
 
-This connects your **OpenAI organization** (the API and platform bill). It does not cover ChatGPT Business or Enterprise seats, which are billed separately.
+This connects the **OpenAI Platform**, your organization's API and developer bill. It does not cover ChatGPT Business or Enterprise seats, which are billed separately.
 
 ## What you'll accomplish
 - Connect with your OpenAI **Admin API key**


### PR DESCRIPTION
Adds the **OpenAI** integration page, mirroring the Cursor docs. Pairs with the connector in JuneOps/june-api#928.

Based on `integration-docs-comms-procurement` (same staging base as the Cursor docs, PR #17), so the OpenAI card/page sits beside Cursor.

## Changes
- **`integrations/openai.mdx`** — new page: what you'll accomplish, what June syncs, capabilities, prerequisites, connect steps (Admin API key).
- **`integrations/ai-tools.mdx`** — OpenAI card in the grid + a line in the attribution note.
- **`docs.json`** — `integrations/openai` in the AI Tools nav group.

## Framing (accurate to the connector)
- This connects the **OpenAI organization** (the API/platform bill), **not** ChatGPT Business/Enterprise seats — stated up front so customers don't mis-scope it.
- Billed, per-person spend with no estimates; **shared/automated usage rolls up at the organization level** (the honest counterpart to the unattributed bucket), so totals reconcile to the OpenAI bill.
- No implementation detail (no endpoints/keys-internals), no em dashes — per the docs style rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)